### PR TITLE
Add custom priority queue and use it in controller.

### DIFF
--- a/Drone/drone_controller.py
+++ b/Drone/drone_controller.py
@@ -32,7 +32,7 @@ class DroneController(DroneControllerBase):
         self.drone = drone
         self._instruction_queue = PriorityQueue()
 
-        coloredlogs.install(level='DEBUG')
+        coloredlogs.install(level=logging.INFO)
 
         # The following two lines are purely for testing purposes. Instructions
         # will be pushed onto the heap as a result of the swarm controller
@@ -106,7 +106,7 @@ class DroneController(DroneControllerBase):
 
         if isinstance(self._task, HoverTask) or self._task is None:
             # Process remaining instructions
-            if self._instruction_queue.size:
+            if not self._instruction_queue.empty():
                 # Stop hovering, if we were doing so
                 if isinstance(self._task, HoverTask):
                     stop_hover_event = self._task.exit_task()

--- a/Drone/drone_controller.py
+++ b/Drone/drone_controller.py
@@ -15,6 +15,7 @@ from ..Utilities import constants as c
 from ..Utilities import drone_exceptions
 from ..Utilities.helper import current_thread_name
 from ..Utilities.lock import SharedLock
+from ..Utilities.priority_queue import PriorityQueue
 
 class DroneController(DroneControllerBase):
     """Manages the control logic of a drone.
@@ -28,18 +29,20 @@ class DroneController(DroneControllerBase):
 
         self._logger = logging.getLogger(__name__)
         self._debug = True
-
         self.drone = drone
+        self._instruction_queue = PriorityQueue()
 
         coloredlogs.install(level='DEBUG')
 
         # The following two lines are purely for testing purposes. Instructions
         # will be pushed onto the heap as a result of the swarm controller
         # sending instructions or inter-drone communication.
-        heapq.heappush(
-            self._instruction_queue, (0, MovementInstruction((5, 5, 0))))
-        heapq.heappush(
-            self._instruction_queue, (0, MovementInstruction((-5, -5, 0))))
+        sample_data1 = (5, 5, 0)
+        sample_data2 = (-5, -5, 0)
+        self._instruction_queue.push(
+            c.Priorities.MEDIUM, MovementInstruction(sample_data1))
+        self._instruction_queue.push(
+            c.Priorities.MEDIUM, MovementInstruction(sample_data2))
 
     def run_loop(self):
         SharedLock.get_lock().acquire()
@@ -103,7 +106,7 @@ class DroneController(DroneControllerBase):
 
         if isinstance(self._task, HoverTask) or self._task is None:
             # Process remaining instructions
-            if len(self._instruction_queue):
+            if self._instruction_queue.size:
                 # Stop hovering, if we were doing so
                 if isinstance(self._task, HoverTask):
                     stop_hover_event = self._task.exit_task()
@@ -116,9 +119,8 @@ class DroneController(DroneControllerBase):
                     self._task = HoverTask(self.drone)
 
     def _read_next_instruction(self):
-        if len(self._instruction_queue):
-            self._current_instruction = heapq.heappop(
-                self._instruction_queue)[1]
+        self._current_instruction = self._instruction_queue.pop()
+        if self._current_instruction is not None:
             self._task = self._current_instruction.get_task(self.drone)
 
     def do_safety_checks(self):

--- a/Drone/drone_controller_base.py
+++ b/Drone/drone_controller_base.py
@@ -24,7 +24,7 @@ class DroneControllerBase():
 
     def __init__(self):
         self._id = None
-        self._instruction_queue = []
+        self._instruction_queue = None
         self._current_instruction = None
         self._task = None
 

--- a/Tests/priority_queue_test.py
+++ b/Tests/priority_queue_test.py
@@ -1,0 +1,37 @@
+import unittest
+
+from ..Utilities.priority_queue import PriorityQueue
+from ..Utilities.constants import Priorities
+
+class TestPriorityQueue(unittest.TestCase):
+    def test_insertion(self):
+        """Test that items are able to be inserted an removed."""
+        queue = PriorityQueue()
+        sample_item = 5
+        queue.push(Priorities.MEDIUM, sample_item)
+        returned_item = queue.pop()
+        self.assertEqual(sample_item, returned_item, "Not inserting and \
+        removing items correctly.")
+
+    def test_proper_order(self):
+        """Test that a mixed-bag of priorities comes out in the right order.""" 
+        queue = PriorityQueue()
+        items = [1, 2, 3]
+        priorities = [Priorities.LOW, Priorities.MEDIUM, Priorities.HIGH]
+        for x in range(0, 3):
+            queue.push(priorities[x], items[x])
+
+        items.reverse()
+        for x in range(0, 3):
+            self.assertEqual(items[x], queue.pop(), "Not returning items with \
+            higher priority first.")
+
+    def test_empty_queue(self):
+        """Test that popping an empty queue does not throw error."""
+        queue = PriorityQueue()
+        item = queue.pop()
+
+        self.assertEqual(item, None)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tests/priority_queue_test.py
+++ b/Tests/priority_queue_test.py
@@ -14,24 +14,34 @@ class TestPriorityQueue(unittest.TestCase):
         removing items correctly.")
 
     def test_proper_order(self):
-        """Test that a mixed-bag of priorities comes out in the right order.""" 
+        """Test that a mixed-bag of priorities comes out in the right order."""
         queue = PriorityQueue()
         items = [1, 2, 3]
         priorities = [Priorities.LOW, Priorities.MEDIUM, Priorities.HIGH]
-        for x in range(0, 3):
-            queue.push(priorities[x], items[x])
+        for item, priority in zip(items, priorities):
+            queue.push(priority, item)
 
         items.reverse()
-        for x in range(0, 3):
-            self.assertEqual(items[x], queue.pop(), "Not returning items with \
+        for item in items:
+            self.assertEqual(item, queue.pop(), "Not returning items with \
             higher priority first.")
 
-    def test_empty_queue(self):
-        """Test that popping an empty queue does not throw error."""
+    def test_pop_empty_queue(self):
+        """Test that popping an empty queue does not throw an error."""
         queue = PriorityQueue()
-        item = queue.pop()
 
+        item = queue.pop()
         self.assertEqual(item, None)
+
+    def test_empty_function(self):
+        """Test that empty returns false when item are in the queue."""
+        queue = PriorityQueue()
+        self.assertTrue(queue.empty(), "Empty queue claiming it is not empty")
+
+
+        queue.push(Priorities.LOW, "Sample string")
+        self.assertFalse(queue.empty(), "Non-empty queue claiming it is \
+        empty.")
 
 if __name__ == '__main__':
     unittest.main()

--- a/Utilities/constants.py
+++ b/Utilities/constants.py
@@ -29,11 +29,18 @@ RANGEFINDER_MIN = 0.29
 RANGEFINDER_EPSILON = 0.03
 DEFAULT_ARM_TIMEOUT = 60
 
-# Values based on heapq, with is a min-heap.
+
 class Priorities(Enum):
+    """Constants for differentiating the priority of items.
+
+    Notes
+    -----
+    Values are based on heapq, with is a min-heap.
+    """
     LOW = 3
     MEDIUM = 2
     HIGH = 1
+
 
 # DroneKit Vehicle Modes
 class Modes(Enum)  :

--- a/Utilities/constants.py
+++ b/Utilities/constants.py
@@ -8,7 +8,6 @@ class Drones(Enum):
     LEONARDO_SIM = "Leonardo_Sim"
     LEONARDO = "Leonardo"
 
-
 DRONES = {
         Drones.LEONARDO_SIM : 'tcp:127.0.0.1:5762',
         Drones.LEONARDO: '/dev/serial/by-id/usb-3D_Robotics_PX4_FMU_v2.x_0-if00'
@@ -29,6 +28,12 @@ MAXIMUM_ALLOWED_ALTITUDE = 4.0
 RANGEFINDER_MIN = 0.29
 RANGEFINDER_EPSILON = 0.03
 DEFAULT_ARM_TIMEOUT = 60
+
+# Values based on heapq, with is a min-heap.
+class Priorities(Enum):
+    LOW = 3
+    MEDIUM = 2
+    HIGH = 1
 
 # DroneKit Vehicle Modes
 class Modes(Enum)  :

--- a/Utilities/priority_queue.py
+++ b/Utilities/priority_queue.py
@@ -1,0 +1,54 @@
+import heapq
+
+class PriorityQueue():
+    """Custom priority queue implementation.
+
+    This purpose of this class is to simplify the insertion and removal of
+    items from the priority queue.
+
+    Attributes
+    ----------
+    _queue: heapq
+        The priority queue.
+    """
+
+    def __init__(self):
+        self._queue = []
+
+    def push(self, priority, item):
+        """Insert an item onto the priority queue.
+
+        Parameters
+        ----------
+        priority : Priority.{LOW, MEDIUM, HIGH}
+            The priority of the task, with higher priority causes the item to
+            "cut ahead" of items of lower priority.
+        item : Any
+            The data being inserted into the queue.
+
+        """
+        heapq.heappush(self._queue, (priority.value, item))
+
+    def pop(self):
+        """Remove the next item from the priortiy queue.
+
+        Returns
+        -------
+        An item, or None if the priority queue is empty.
+        """
+        if (self.size > 0):
+            # Index 0 is priority, index 1 is the item.
+            return heapq.heappop(self._queue)[1]
+        else:
+            return None
+
+    @property
+    def size(self):
+        """Get the size of the priority queue.
+        """
+        return len(self._queue)
+
+    def clear(self):
+        """Empty out the priority queue, deleting all the items.
+        """
+        self.queue = []

--- a/Utilities/priority_queue.py
+++ b/Utilities/priority_queue.py
@@ -36,19 +36,29 @@ class PriorityQueue():
         -------
         An item, or None if the priority queue is empty.
         """
-        if (self.size > 0):
+        if len(self):
             # Index 0 is priority, index 1 is the item.
             return heapq.heappop(self._queue)[1]
         else:
             return None
 
-    @property
-    def size(self):
-        """Get the size of the priority queue.
+    def empty(self):
+        """Check if the priority queue is empty.
+
+        Returns
+        -------
+        bool
+            True if the priority queue is empty, and false otherwise.
         """
-        return len(self._queue)
+        if not len(self):
+            return True
+        else:
+            return False
 
     def clear(self):
         """Empty out the priority queue, deleting all the items.
         """
         self.queue = []
+
+    def __len__(self):
+        return len(self._queue)


### PR DESCRIPTION
A new priority queue class to abstract the details of pushing and popping the queue. The priority queue is used in drone controller to keep track of instructions. Benefits of this pull request are:

- Constant enum for three priority levels: LOW, MEDIUM, and HIGH (previously hard-coded)
- Abstraction of popping the queue, which used to require indexing into the popped item to retrieve the desired data

I wrote unit tests for this one, as I plan to do for all future pull requests.