### PR TITLE
Maintain order for items of equal priority.

### DIFF
--- a/Tests/priority_queue_test.py
+++ b/Tests/priority_queue_test.py
@@ -16,12 +16,13 @@ class TestPriorityQueue(unittest.TestCase):
     def test_proper_order(self):
         """Test that a mixed-bag of priorities comes out in the right order."""
         queue = PriorityQueue()
-        items = [1, 2, 3]
-        priorities = [Priorities.LOW, Priorities.MEDIUM, Priorities.HIGH]
+        items = [1, 2, 3, 4]
+        priorities = [Priorities.LOW, Priorities.LOW, Priorities.MEDIUM,
+            Priorities.HIGH]
         for item, priority in zip(items, priorities):
             queue.push(priority, item)
 
-        items.reverse()
+        items = [4, 3, 1, 2]
         for item in items:
             self.assertEqual(item, queue.pop(), "Not returning items with \
             higher priority first.")

--- a/Utilities/priority_queue.py
+++ b/Utilities/priority_queue.py
@@ -12,6 +12,8 @@ class PriorityQueue():
         The priority queue.
     """
 
+    count = 987654
+
     def __init__(self):
         self._queue = []
 
@@ -27,7 +29,9 @@ class PriorityQueue():
             The data being inserted into the queue.
 
         """
-        heapq.heappush(self._queue, (priority.value, item))
+        val = int('{}{}'.format(priority.value, PriorityQueue.count))
+        PriorityQueue.count = PriorityQueue.count + 1
+        heapq.heappush(self._queue, (val, item))
 
     def pop(self):
         """Remove the next item from the priortiy queue.

--- a/Utilities/priority_queue.py
+++ b/Utilities/priority_queue.py
@@ -1,5 +1,7 @@
 import heapq
 
+DEFAULT_COUNT = 900000
+
 class PriorityQueue():
     """Custom priority queue implementation.
 
@@ -12,7 +14,7 @@ class PriorityQueue():
         The priority queue.
     """
 
-    count = 900000
+    count = DEFAULT_COUNT
 
     def __init__(self):
         self._queue = []
@@ -30,7 +32,7 @@ class PriorityQueue():
 
         """
         val = int('{}{}'.format(priority.value, PriorityQueue.count))
-        PriorityQueue.count = PriorityQueue.count + 1
+        PriorityQueue.count += 1
         heapq.heappush(self._queue, (val, item))
 
     def pop(self):

--- a/Utilities/priority_queue.py
+++ b/Utilities/priority_queue.py
@@ -12,7 +12,7 @@ class PriorityQueue():
         The priority queue.
     """
 
-    count = 987654
+    count = 900000
 
     def __init__(self):
         self._queue = []


### PR DESCRIPTION
Items of equal priority inserted into a PriorityQueue did not maintain order. For instance, if two movement instruction of equal priority were pushed onto the queue, they would be executed in reverse order, which is probably not what was intended.

I'm not sure if my solution is the best way to do it, but it gets the job done. PriorityQueue keeps an internal counter starting at 987654. When items are inserted, their priority level is appended to the front of this counter. So if I insert two movements of equal priority the first gets id 3987654 and the second gets 3987655, and so the first one gets popped out first (since it's a min-heap).

This method would cease to work after 1000000 - 987654 = 12346 items were queued, after which the number would jump in magnitude and cause things to break (11000000 > 3999999).