### PR TITLE
Tested requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,16 @@
 dronekit == 2.9.1
-pymavlink == 2.2.1
+pymavlink == 2.2.21
 mavproxy == 1.7.7
 coloredlogs
 simple_pid
 matplotlib
 numpy
+flask
+pandas
+setuptools
+future
+lxml
+opencv-python
+scipy
+sklearn
+serial


### PR DESCRIPTION
I have tested requirements.txt and found 1 major problem, and multiple lesser problems:

- Major: pymavlink was set to install version 2.2.1 instead of 2.2.21
- Minor: I added all of the modules installed in IARC_RL_WORLD, also added flask

Also of note: the real-time graphing requires that the python-tk _package_ is installed. Maybe this can be added to our ansible script.