### PR TITLE
Updated to check if the drone is armable before arming

### DIFF
--- a/flight/drone/drone.py
+++ b/flight/drone/drone.py
@@ -133,7 +133,8 @@ class Drone(Vehicle):
 
         self._logger.info('Arming...')
         while not self.armed:
-            self.armed = True
+            if self.is_armable:
+                self.armed = True
             time.sleep(c.ARM_RETRY_DELAY)
 
         if self.armed:


### PR DESCRIPTION
The previous code was potentially trying to arm the drone before the drone was able to be armed and this was causing a safety error.